### PR TITLE
Fix old class name

### DIFF
--- a/src/particle-analysis/EventCharacteristics.py
+++ b/src/particle-analysis/EventCharacteristics.py
@@ -39,7 +39,7 @@ class EventCharacteristics:
         norm=0
         if harmonic_n < 1:
             raise ValueError("Eccentricity is only defined for positive expansion orders.")
-        for particle in self.particle_data:
+        for particle in self.particle_data_:
             if weight_quantity == "energy":
                 weight = particle.E
             elif weight_quantity == "number":


### PR DESCRIPTION
Apparently the merge on the eccentricity branch did not work as expected. This fixed the old class name in the imports.