### PR TITLE
Check for 0 denominator

### DIFF
--- a/src/sparkx/Particle.py
+++ b/src/sparkx/Particle.py
@@ -866,7 +866,12 @@ class Particle:
         float
             momentum rapidity
         """
-        return 0.5 * np.log((self.E + self.pz) / (self.E - self.pz))
+        if abs(self.E - self.pz) < 1e-10:
+            denominator = (self.E - self.pz) + 1e-10  # Adding a small positive value
+        else:
+            denominator = (self.E - self.pz)
+    
+        return 0.5 * np.log((self.E + self.pz) / denominator)
 
     def p_abs(self):
         """
@@ -927,7 +932,12 @@ class Particle:
         float
             pseudorapidity
         """
-        return 0.5 * np.log((self.p_abs()+self.pz) / (self.p_abs()-self.pz))
+        if abs(self.p_abs() - self.pz) < 1e-10:
+            denominator = (self.p_abs() - self.pz) + 1e-10  # Adding a small positive value
+        else:
+            denominator = (self.p_abs() - self.pz)
+
+        return 0.5 * np.log((self.p_abs()+self.pz) / denominator)
 
     def spatial_rapidity(self):
         """


### PR DESCRIPTION
Rapidity can crash when reading from files with limited accuracy. This is the most performant fix for this issue.