### PR TITLE
Roch/numpy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ The main categories for changes in this file are:
 
 A `Deprecated` section could be added if needed for soon-to-be removed features.
 
+## v2.3.0-Chatelet
+Date: 2026-XX-XX
+
+### Changed
+* Particle: Refactor class to use more efficient internal data structures to save memory.
+
+### Fixed
+* Failing import of `JetAnalysis` if `fastjet` is not installed or not compatible with the current numpy/python version. Now if the import fails, the user can still use all other features of SPARKX, but the `JetAnalysis` class will not be available.
+
+[Link to diff from previous version](https://github.com/smash-transport/sparkx/compare/v2.2.0...v2.3.0)
+
 ## v2.2.0-Chatelet
 Date: 2026-03-04
 

--- a/src/sparkx/JetAnalysis.py
+++ b/src/sparkx/JetAnalysis.py
@@ -8,8 +8,10 @@
 # ===================================================
 
 import numpy as np
+
 try:
     import fastjet as fj  # type: ignore
+
     _FASTJET_AVAILABLE = True
 except Exception:
     _FASTJET_AVAILABLE = False

--- a/src/sparkx/JetAnalysis.py
+++ b/src/sparkx/JetAnalysis.py
@@ -8,7 +8,11 @@
 # ===================================================
 
 import numpy as np
-import fastjet as fj  # type: ignore
+try:
+    import fastjet as fj  # type: ignore
+    _FASTJET_AVAILABLE = True
+except Exception:
+    _FASTJET_AVAILABLE = False
 import csv
 import warnings
 from sparkx.Particle import Particle

--- a/src/sparkx/__init__.py
+++ b/src/sparkx/__init__.py
@@ -18,6 +18,7 @@ from sparkx.flow.PCAFlow import PCAFlow
 from sparkx.flow.GenerateFlow import GenerateFlow
 from sparkx.Histogram import Histogram
 from sparkx.Jackknife import Jackknife
+
 try:
     from sparkx.JetAnalysis import JetAnalysis
 except Exception:

--- a/src/sparkx/__init__.py
+++ b/src/sparkx/__init__.py
@@ -18,7 +18,10 @@ from sparkx.flow.PCAFlow import PCAFlow
 from sparkx.flow.GenerateFlow import GenerateFlow
 from sparkx.Histogram import Histogram
 from sparkx.Jackknife import Jackknife
-from sparkx.JetAnalysis import JetAnalysis
+try:
+    from sparkx.JetAnalysis import JetAnalysis
+except Exception:
+    pass
 from sparkx.Jetscape import Jetscape
 from sparkx.Lattice3D import Lattice3D
 from sparkx.loader.BaseLoader import BaseLoader

--- a/tests/test_JetAnalysis.py
+++ b/tests/test_JetAnalysis.py
@@ -8,11 +8,19 @@
 # ===================================================
 
 from sparkx.Jetscape import Jetscape
-from sparkx.JetAnalysis import JetAnalysis
+try:
+    from sparkx.JetAnalysis import JetAnalysis
+    _FASTJET_AVAILABLE = True
+except Exception:
+    _FASTJET_AVAILABLE = False
 import HelperFunctions as hf
 import pytest
 import os
 import csv
+
+pytestmark = pytest.mark.skipif(
+    not _FASTJET_AVAILABLE, reason="fastjet not available"
+)
 
 TEST_FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
 TEST_JETSCAPE_DAT = os.path.join(TEST_FILES_DIR, "test_jetscape.dat")

--- a/tests/test_JetAnalysis.py
+++ b/tests/test_JetAnalysis.py
@@ -8,8 +8,10 @@
 # ===================================================
 
 from sparkx.Jetscape import Jetscape
+
 try:
     from sparkx.JetAnalysis import JetAnalysis
+
     _FASTJET_AVAILABLE = True
 except Exception:
     _FASTJET_AVAILABLE = False


### PR DESCRIPTION
I noticed that sparkx fails the import with * when going to more modern numpy environments (v2.x), where fastjet and awkward arrays have some compatibility issues.
This PR catches the import in case of failure, so the user can still use sparkx, but not the JetAnalysis class in these environments.
The tests are skipped in this scenario.
I also add here the CHANGELOG entry I was missing for PR #396.